### PR TITLE
Triggering camera scanner from the main thread

### DIFF
--- a/ios/BlinkIDReactNative/BlinkIDReactNative/BlinkIDReactNative.mm
+++ b/ios/BlinkIDReactNative/BlinkIDReactNative/BlinkIDReactNative.mm
@@ -89,7 +89,9 @@ RCT_EXPORT_METHOD(scan:(NSDictionary*)scanOptions callback:(RCTResponseSenderBlo
     scanningViewController.supportedOrientations = UIInterfaceOrientationMaskAll;
     
     UIViewController *rootViewController = [[[UIApplication sharedApplication] keyWindow] rootViewController];
-    [rootViewController presentViewController:scanningViewController animated:YES completion:nil];
+    dispatch_sync(dispatch_get_main_queue(), ^{
+        [rootViewController presentViewController:scanningViewController animated:YES completion:nil];
+    });
     
 }
 


### PR DESCRIPTION
All UI changes should be triggered from the main thread. Doing this prevents from falling into the `accessing _cachedsystemanimationfence requires the main thread` exception that may appear in some scenarios. 